### PR TITLE
Only append the project name to the artifact when it is dirty.

### DIFF
--- a/src/main/groovy/net/minecrell/vanillagradle/BaseVanillaPlugin.groovy
+++ b/src/main/groovy/net/minecrell/vanillagradle/BaseVanillaPlugin.groovy
@@ -24,8 +24,10 @@ package net.minecrell.vanillagradle
 
 import net.minecraftforge.gradle.GradleConfigurationException
 import net.minecraftforge.gradle.delayed.DelayedFile
+import net.minecraftforge.gradle.tasks.DecompileTask
 import net.minecraftforge.gradle.tasks.ProcessJarTask
 import net.minecraftforge.gradle.user.UserBasePlugin
+import net.minecraftforge.gradle.user.UserConstants
 import net.minecraftforge.gradle.user.UserExtension
 import org.gradle.api.logging.Logger
 import org.gradle.api.plugins.JavaPluginConvention
@@ -46,6 +48,18 @@ abstract class BaseVanillaPlugin<T extends UserExtension> extends UserBasePlugin
         project.with {
             ProcessJarTask binDeobf = tasks.deobfBinJar
             ProcessJarTask decompDeobf = tasks.deobfuscateJar
+            DecompileTask decompile = tasks.decompile
+
+            // bin jar
+            def binName = getBinDepName() + "_${project.name}-{MC_VERSION}.jar";
+            binDeobf.setOutDirtyJar(delayedFile("${UserConstants.DIRTY_DIR}/$binName"))
+
+            // srg jar
+            def srgName = "{API_NAME}_${project.name}-{MC_VERSION}-${UserConstants.CLASSIFIER_DEOBF_SRG}.jar"
+            decompDeobf.setOutDirtyJar(delayedFile("${UserConstants.DIRTY_DIR}/$srgName"))
+
+            // src jar
+            decompile.setOutJar(delayedDirtyFile(null, UserConstants.CLASSIFIER_DECOMPILED, "jar", false))
 
             JavaPluginConvention java = convention.plugins['java']
             SourceSet main = java.sourceSets.main
@@ -69,12 +83,12 @@ abstract class BaseVanillaPlugin<T extends UserExtension> extends UserBasePlugin
 
     @Override
     protected String getSrcDepName() {
-        "minecraft_${project.name}_src"
+        "minecraft_merged_src"
     }
 
     @Override
     protected String getBinDepName() {
-        "minecraft_${project.name}_bin"
+        "minecraft_merged_bin"
     }
 
     @Override
@@ -94,7 +108,7 @@ abstract class BaseVanillaPlugin<T extends UserExtension> extends UserBasePlugin
 
     @Override
     protected String getApiCacheDir(T ext) {
-        '{BUILD_DIR}/minecraft/net/minecraft/minecraft_merged/{MC_VERSION}'
+        '{CACHE_DIR}/minecraft/net/minecraft/minecraft_merged/{MC_VERSION}'
     }
 
     @Override
@@ -171,4 +185,27 @@ abstract class BaseVanillaPlugin<T extends UserExtension> extends UserBasePlugin
         null
     }
 
+    @Override
+    DelayedFile delayedDirtyFile(String name, String classifier, String ext, boolean mappings) {
+        new DelayedDirtyFile(name, classifier, ext, mappings, project, "", this)
+    }
+
+    @Override
+    protected void setMinecraftDeps(boolean decomp, boolean remove) {
+        String version = this.getMcVersion((UserExtension)this.getExtension())
+
+        def name;
+        if (decomp)
+            name = getSrcDepName()
+         else
+            name = getBinDepName()
+        if (!project.tasks.deobfuscateJar.isClean())
+            name += "_$project.name"
+
+        project.dependencies.add "minecraft", ["name":name, "version":version]
+        if(remove) {
+            project.configurations.minecraft.exclude(["module":name])
+        }
+
+    }
 }

--- a/src/main/groovy/net/minecrell/vanillagradle/BaseVanillaPlugin.groovy
+++ b/src/main/groovy/net/minecrell/vanillagradle/BaseVanillaPlugin.groovy
@@ -29,6 +29,7 @@ import net.minecraftforge.gradle.tasks.ProcessJarTask
 import net.minecraftforge.gradle.user.UserBasePlugin
 import net.minecraftforge.gradle.user.UserConstants
 import net.minecraftforge.gradle.user.UserExtension
+
 import org.gradle.api.logging.Logger
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.SourceSet
@@ -51,7 +52,7 @@ abstract class BaseVanillaPlugin<T extends UserExtension> extends UserBasePlugin
             DecompileTask decompile = tasks.decompile
 
             // bin jar
-            def binName = getBinDepName() + "_${project.name}-{MC_VERSION}.jar";
+            def binName = getBinDepName() + "_${project.name}-{MC_VERSION}.jar"
             binDeobf.setOutDirtyJar(delayedFile("${UserConstants.DIRTY_DIR}/$binName"))
 
             // srg jar
@@ -194,10 +195,10 @@ abstract class BaseVanillaPlugin<T extends UserExtension> extends UserBasePlugin
     protected void setMinecraftDeps(boolean decomp, boolean remove) {
         String version = this.getMcVersion((UserExtension)this.getExtension())
 
-        def name;
+        def name
         if (decomp)
             name = getSrcDepName()
-         else
+        else
             name = getBinDepName()
         if (!project.tasks.deobfuscateJar.isClean())
             name += "_$project.name"

--- a/src/main/groovy/net/minecrell/vanillagradle/DelayedDirtyFile.java
+++ b/src/main/groovy/net/minecrell/vanillagradle/DelayedDirtyFile.java
@@ -24,11 +24,13 @@ package net.minecrell.vanillagradle;
 
 import net.minecraftforge.gradle.delayed.DelayedFile;
 import net.minecraftforge.gradle.tasks.ProcessJarTask;
+
 import org.gradle.api.Project;
 
 import java.io.File;
 
 // java class because I couldn't get groovy to behave
+@SuppressWarnings("serial")
 public class DelayedDirtyFile extends DelayedFile {
 
     private String name;
@@ -36,7 +38,7 @@ public class DelayedDirtyFile extends DelayedFile {
     private String ext;
     private boolean mappings;
 
-    public DelayedDirtyFile(String name, String classifier, String ext, boolean mappings, Project owner, String pattern, IDelayedResolver... resolvers) {
+    public DelayedDirtyFile(String name, String classifier, String ext, boolean mappings, Project owner, String pattern, IDelayedResolver<?>... resolvers) {
         super(owner, pattern, resolvers);
         this.name = name;
         this.classifier = classifier;
@@ -44,6 +46,7 @@ public class DelayedDirtyFile extends DelayedFile {
         this.mappings = mappings;
     }
 
+    @Override
     public File resolveDelayed() {
         ProcessJarTask decompDeobf = (ProcessJarTask) this.project.getTasks().getByName("deobfuscateJar");
         pattern = (decompDeobf.isClean() ? "{API_CACHE_DIR}/" + (mappings ? "{MAPPING_CHANNEL}/{MAPPING_VERSION}/" : "") : "{BUILD_DIR}/dirtyArtifacts") + "/";

--- a/src/main/groovy/net/minecrell/vanillagradle/DelayedDirtyFile.java
+++ b/src/main/groovy/net/minecrell/vanillagradle/DelayedDirtyFile.java
@@ -1,0 +1,73 @@
+/*
+ * VanillaGradle - Temporary ForgeGradle extension for Vanilla mods
+ * Copyright (c) 2015, Minecrell <https://github.com/Minecrell>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package net.minecrell.vanillagradle;
+
+import net.minecraftforge.gradle.delayed.DelayedFile;
+import net.minecraftforge.gradle.tasks.ProcessJarTask;
+import org.gradle.api.Project;
+
+import java.io.File;
+
+// java class because I couldn't get groovy to behave
+public class DelayedDirtyFile extends DelayedFile {
+
+    private String name;
+    private String classifier;
+    private String ext;
+    private boolean mappings;
+
+    public DelayedDirtyFile(String name, String classifier, String ext, boolean mappings, Project owner, String pattern, IDelayedResolver... resolvers) {
+        super(owner, pattern, resolvers);
+        this.name = name;
+        this.classifier = classifier;
+        this.ext = ext;
+        this.mappings = mappings;
+    }
+
+    public File resolveDelayed() {
+        ProcessJarTask decompDeobf = (ProcessJarTask) this.project.getTasks().getByName("deobfuscateJar");
+        pattern = (decompDeobf.isClean() ? "{API_CACHE_DIR}/" + (mappings ? "{MAPPING_CHANNEL}/{MAPPING_VERSION}/" : "") : "{BUILD_DIR}/dirtyArtifacts") + "/";
+
+        if (!isNullOrEmpty(name)) {
+            pattern += name;
+        } else {
+            pattern += "{API_NAME}";
+        }
+
+        if (!decompDeobf.isClean())
+            pattern += "_" + project.getName();
+        pattern += "-{MC_VERSION}";
+
+        if (!isNullOrEmpty(classifier))
+            pattern += "-" + classifier;
+        if (!isNullOrEmpty(ext))
+            pattern += "." + ext;
+
+        return super.resolveDelayed();
+    }
+
+    public boolean isNullOrEmpty(String s) {
+        return s == null || s.isEmpty();
+    }
+
+}


### PR DESCRIPTION
This took a lot of doing and code searching. The easiest part was the binJar. Next was the srgJar, but that required some extra code to get it to not break things.

In order to get around those issues, I overrode `delayedDirtyFile` and put the project name in that one. Unfortunately, it still wasn't being added to the classpath, so I would have to override `setMinecraftDeps` to alleviate that.

The one thing I actually had trouble on was extending CachedFile. Gradle was complaining about `pattern` not existing. Converting it to a java file seemed to fix it. It's still in the groovy folder, but it seems to still compile.
